### PR TITLE
update 03 readme

### DIFF
--- a/exercises/03/readme.md
+++ b/exercises/03/readme.md
@@ -4,126 +4,34 @@ The scenario upon which this Virtual Event is based includes access to an on-pre
 
 > The SAP system we'll be using is not actually on-prem, it's the [public SAP NetWeaver Gateway Demo system](https://blogs.sap.com/2017/06/16/netweaver-gateway-demo-es5-now-in-beta/), known by its System ID "ES5". But for the purposes of understanding and configuring the SAP Cloud Connector, we will treat it as if it is.
 
-In this exercise you'll set up SAP Cloud Connector, to provide the connection between an on-prem SAP system (ES5) and your subaccount on the SAP Cloud Platform, enabling services and apps running in that subaccount to access specific system endpoints in ES5.
+In this exercise you'll set up and configure SAP Cloud Connector, to provide the connection between an on-prem SAP system (ES5) and your subaccount on the SAP Cloud Platform, enabling services and apps running in that subaccount to access specific system endpoints in ES5.
 
-The setup will be done in a container, to isolate SAP Cloud Connector and the software upon which it relies. This is a good approach not only for Virtual Event scenarios like this where attendees' machines are all different, but also for use within work environments. Docker will be used as the container system.
-
-> The following instructions are based in part on the [nzamani/sap-cloud-connector-docker](https://github.com/nzamani/sap-cloud-connector-docker) repository on GitHub. If you want to find out more, check out the blog post "[Installing SAP Cloud Connector into Docker and connecting it to SAP Cloud Platform](https://blogs.sap.com/2018/05/22/installing-sap-cloud-connector-into-docker-and-connecting-it-to-sap-cloud-platform/)" by [Nabi Zamani](https://people.sap.com/pars.man#overview).
+The setup will be done in a container, to isolate SAP Cloud Connector and the software upon which it relies. This is a good approach not only for Virtual Event scenarios like this where attendees' machines are all different, but also for use within work environments. Docker is used as the container system.
 
 > This exercise assumes you don't already have any processes listening for HTTP requests on port 8443 of your machine.
 
 ## Steps
 
-After completing these steps you'll have an SAP Cloud Connector system running in a container on your machine.
+After completing these steps you'll have an SAP Cloud Connector system running in a container on your machine and connected to your trial account. You'll also have resources in the ES5 system exposed and available through that system too.
 
-### 1. Prepare the environment for the Docker image
+### 1. Install an SAP Cloud Connector
 
-:point_right: Create a new directory called `container-scc/` (for example, in your home directory) and within that directory create a subdirectory called `sapdownloads/`.
+Instructions for setting up an SAP Cloud Connector, along with the software upon which it relies, all in a Docker container, is explained in detail in the [nzamani/sap-cloud-connector-docker](https://github.com/nzamani/sap-cloud-connector-docker) repository on GitHub. This repository is accompanied by the blog post "[Installing SAP Cloud Connector into Docker and connecting it to SAP Cloud Platform](https://blogs.sap.com/2018/05/22/installing-sap-cloud-connector-into-docker-and-connecting-it-to-sap-cloud-platform/)" by [Nabi Zamani](https://people.sap.com/pars.man#overview).
 
-The `container-scc/` directory will contain the build instructions for the Docker image that the container will be based upon, and the appropriate software to run the SAP Cloud Connector within it.
+:point_right: Follow the [instructions](https://github.com/nzamani/sap-cloud-connector-docker#instructions) in this repository to set things up; at the end you should have a Docker container based SAP Cloud Connector up and running, and you should have successfully logged in (at https://localhost:8443) as user "Administrator".
 
-:point_right: Go to the [cloud section of the SAP Development Tools website](https://tools.hana.ondemand.com/#cloud) and download the latest Cloud Connector component, placing it into the `sapdownloads/` directory. Regardless of your local machine's operating system, you will need to download for Linux, as that is what the container will be running. At the time of writing the version is 2.12.0.1 - make sure you download the ZIP file for Linux as indicated, taking the latest version:
+Once you've done that, return here for the following steps in this README.
 
-![SAP Cloud Connector download](sccdownload.png)
 
-:point_right: From the same page, now download the latest SAP Java Virtual Machine (JVM) into the `sapdownloads/` directory, again for Linux, and specifically the `.rpm` component, as indicated:
+### 2. Perform initial setup of the SAP Cloud Connector
 
-![SAP JVM download](jvmdownload.png)
-
-> the screenshots here are for illustration purposes - the version numbers of the SAP Cloud Connector and SAP JVM components will most likely be different to the ones you see here.
-
-:point_right: Finally in this step, create a new file called `Dockerfile` in the `container-scc/` directory (noting the capitalization and lack of extension on this file name).
-
-:point_right: Into this file, copy the contents of the [`Dockerfile`](Dockerfile) in this repository.
-
-Here's a quick illustration of what you should have, from a directory and file point of view (again, the version numbers may differ):
-
-```
-.
-├── Dockerfile
-└── sapdownloads
-    ├── sapcc-2.12.0.1-linux-x64.zip
-    └── sapjvm-8.1.053-linux-x64.rpm
-```
-
-### 2. Build the Docker image
-
-Now you have everything ready to build the Docker image that will enable you to instantiate a Linux-based container running the SAP Cloud Connector. The `Dockerfile` contains instructions to build that image, and are briefly as follows:
-
-- base the image on the [CentOS](https://www.centos.org) Linux distribution (which has a reasonably small footprint)
-- on top of the base image install some core tools
-- copy across, from the host (your machine) to the image, the two files you downloaded (the SAP JVM and the SAP Cloud Connector component)
-- unpack and install the SAP JVM and SAP Cloud Connector
-- set up a shell & user (`sccadmin`) and instructions to start up the SAP Cloud Connector for when a container is created
-
-So now you must build the image, and after that you can instantiate a container from that image.
-
-:point_right: In the `container-scc/` directory (where the `Dockerfile` file is located), build the image as follows:
-
-```bash
-docker build -t scc .
-```
-
-(don't forget the period at the end, denoting "this directory".)
-
-> the build process may take a few mins, as components that make up the image need to be downloaded and then installed.
-
-You can look for the image that's produced, with the following command:
-
-```bash
-docker image ls
-```
-
-The output will look something like this (you may have fewer entries), showing the new "scc" entry in the "REPOSITORY" column:
-
-```
-REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-scc                 latest              acb6d16f23da        9 seconds ago       863MB
-centos              7                   9f38484d220f        2 months ago        202MB
-[...]
-```
-
-### 3. Instantiate a container
-
-Now you have an image, it's time to instantiate a container from it. This will have Cloud Connector running inside it.
-
-:point_right: Instantiate the container as follows:
-
-```bash
-docker run -p 8443:8443 --name myscc -d scc
-```
-
-Briefly, the parameters used here do the following:
-
-- `-p 8443:8443`: make port 8443 in the container available on the host machine (remember, SAP Cloud Connector listens by default on port 8443 and you want to be able to connect to it with your browser on your host machine)
-- `--name myscc`: this gives a human-friendly name to the container that can be used to refer to it in any subsequent commands
-- `-d`: run the container in "detached" mode, i.e. in the background
-- `scc`: this is the name of the image from which the container is to be created
-
-Because the container is started in the background, the output from this command is the ID of that container.
-
-:point_right: Check that the container is running, with another Docker command, thus:
-
-```bash
-docker ps
-```
-
-You should see output that looks something like this:
-
-```
-CONTAINER ID   IMAGE   COMMAND                  CREATED             STATUS         PORTS                    NAMES
-c8e4073f42a4   scc     "/bin/sh -c '/opt/sa…"   About an hour ago   Up 9 seconds   0.0.0.0:8443->8443/tcp   myscc
-```
-
-### 4. Connect to perform initial setup of the SAP Cloud Connector
-
-In this step you will log on to the SAP Cloud Connector in your browser, and use the administration interface to perform some initial setup, in particular, connecting it to the SAP Cloud Platform.
+In this step you will use the administration interface to perform some initial setup of the SAP Cloud Connector; in particular, you'll connect it to the SAP Cloud Platform.
 
 :point_right: Open your browser and go to the SAP Cloud Connector administration UI at [https://localhost:8443](https://localhost:8443). Remember that this is only possible because, with the `-p 8443:8443` parameter earlier, you specified that port 8443 in the container (which is where SAP Cloud Connector is *actually* running and listening) should be exposed to your machine, the container's host (where Docker is running), also on port 8443.
 
-> Your browser will likely warn you that the site is insecure, because the certificate that the site presents (via HTTPS) has not been signed by any authority it recognizes. This is OK for what we want to achieve in this Virtual Event, and you should proceed through any warning. It's possible to fix this by installing a signed certificate into the SAP Cloud Connector, but this is beyond the scope of this exercise.
+> Your browser will likely warn you that the site is insecure, because the certificate that the site presents (via HTTPS) has not been signed by any authority it recognizes. This is OK for what we want to achieve in this Virtual Event, and you should proceed through any warning. It's possible to fix this by installing a signed certificate into the SAP Cloud Connector, but this is beyond the scope of this exercise. Check the [Browsers](https://github.com/nzamani/sap-cloud-connector-docker#browsers) section of the other repository for information on how to proceed past the warnings.
 
-:point_right: At the "Cloud Connector Login" page, log in with the default username and password "Administrator" and "manage". You're then prompted to change this password which you should do, selecting the "Save" icon on the right hand side to proceed (leave other options as they are).
+:point_right: If you haven't done already, at the "Cloud Connector Login" page, log in with the default username and password "Administrator" and "manage" and then follow the prompts to change this password, selecting the "Save" icon on the right hand side to proceed (leave other options as they are).
 
 Next, you're asked to specify an initial subaccount that you want the SAP Cloud Connector to connect to (you can connect it to multiple subaccounts but we will only specify this initial one in this exercise).
 


### PR DESCRIPTION
Now we're pointing to nzamani/sap-cloud-connector-docker for all the
instructions as to how to set up and run SAP Cloud Connector in a Docker
container.
